### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/ecma6/arrayComprehension.md
+++ b/ecma6/arrayComprehension.md
@@ -1,4 +1,4 @@
-#Array Comprehension
+# Array Comprehension
 
 The array comprehension syntax is a JavaScript expression which allows you to quickly assemble a new array based on an existing one. Comprehensions exist in many programming languages and the upcoming *ECMAScript 7* standard defines array comprehensions for JavaScript.
 

--- a/ecma6/arrows.md
+++ b/ecma6/arrows.md
@@ -1,8 +1,8 @@
-#Arrows
+# Arrows
 
 Arrows are a function shorthand using the => syntax. They are syntactically similar to the related feature in C#, Java 8 and CoffeeScript. They support both expression and statement bodies. Unlike functions, arrows share the same lexical this as their surrounding code.
 
-##Expression bodies
+## Expression bodies
 
 > ES6:
 
@@ -24,7 +24,7 @@ var nums = evens.map(function (v, i) {
 });
 ```
 
-##Statement bodies
+## Statement bodies
 
 > ES6:
 
@@ -42,7 +42,7 @@ nums.forEach(function (v) {
 });
 ```
 
-##Lexical `this`
+## Lexical `this`
 > ES6:
 
 ```js

--- a/ecma6/classes.md
+++ b/ecma6/classes.md
@@ -1,4 +1,4 @@
-#Classes
+# Classes
 
 ES6 classes are a simple sugar over the prototype-based OO pattern. Having a single convenient declarative form makes class patterns easier to use, and encourages interoperability. Classes support prototype-based inheritance, super calls, instance and static methods and constructors.
 
@@ -25,7 +25,7 @@ SkinnedMesh.defaultMatrix = function defaultMatrix() {
 };
 ```
 
-##Constructor
+## Constructor
 
 > ES6:
 
@@ -63,7 +63,7 @@ SkinnedMesh.defaultMatrix = function defaultMatrix() {
 };
 ```
 
-##Extends
+## Extends
 
 > ES6:
 

--- a/ecma6/default.md
+++ b/ecma6/default.md
@@ -1,8 +1,8 @@
-#Default, Rest, Spread
+# Default, Rest, Spread
 
 Callee-evaluated default parameter values. Turn an array into consecutive arguments in a function call. Bind trailing parameters to an array. Rest replaces the need for arguments and addresses common cases more directly.
 
-##Default
+## Default
 > ES6:
 
 ```js
@@ -20,7 +20,7 @@ function f(x) {
 }
 ```
 
-##Rest
+## Rest
 > ES6:
 
 ```js
@@ -39,7 +39,7 @@ function f(x) {
 }
 ```
 
-##Spread
+## Spread
 Pass each elem of array as argument
 > ES6:
 

--- a/ecma6/destructuring.md
+++ b/ecma6/destructuring.md
@@ -1,8 +1,8 @@
-#Destructuring
+# Destructuring
 
 Destructuring allows binding using pattern matching, with support for matching arrays and objects. Destructuring is fail-soft, similar to standard object lookup foo["bar"], producing undefined values when not found.
 
-##List matching
+## List matching
 > ES6:
 
 ```js
@@ -18,7 +18,7 @@ var a = ref[0];
 var b = ref[2];
 ```
 
-##Object matching
+## Object matching
 > ES6:
 
 ```js
@@ -35,7 +35,7 @@ var b = _getSomething.second.something;
 var c = _getSomething.third;
 ```
 
-##Object matching shorthand
+## Object matching shorthand
 > ES6:
 
 ```js
@@ -52,7 +52,7 @@ var second = _getSomething.second;
 var third = _getSomething.third;
 ```
 
-##Parameter destructuring
+## Parameter destructuring
 > ES6:
 
 ```js
@@ -72,7 +72,7 @@ function g(_ref) {
 g({ name: 5 });
 ```
 
-##Fail-soft destructuring
+## Fail-soft destructuring
 > ES6:
 
 ```js
@@ -80,7 +80,7 @@ var [a] = [];
 ```
 a === undefined;
 
-##Fail-soft destructuring with defaults
+## Fail-soft destructuring with defaults
 > ES6:
 
 ```js

--- a/ecma6/generators.md
+++ b/ecma6/generators.md
@@ -1,4 +1,4 @@
-#Generators
+# Generators
 
 Generators simplify iterator-authoring using function* and yield. A function declared as function* returns a Generator instance. Generators are subtypes of iterators which include additional next and throw. These enable values to flow back into the generator, so yield is an expression form which returns a value (or throws).
 

--- a/ecma6/iterators.md
+++ b/ecma6/iterators.md
@@ -1,4 +1,4 @@
-#Iterators, For..Of
+# Iterators, For..Of
 Iterator objects enable custom iteration like CLR IEnumerable or Java Iterable. Generalize for..in to custom iterator-based iteration with for..of. Don’t require realizing an array, enabling lazy design patterns like LINQ.
 
 > ES6

--- a/ecma6/let.md
+++ b/ecma6/let.md
@@ -1,4 +1,4 @@
-#Let, Const
+# Let, Const
 
 Block-scoped binding constructs. let is the new var. const is single-assignment. Static restrictions prevent use before assignment.
 

--- a/ecma6/modules.md
+++ b/ecma6/modules.md
@@ -1,8 +1,8 @@
-#Modules
+# Modules
 
 Language-level support for modules for component definition. Codifies patterns from popular JavaScript module loaders (AMD, CommonJS). Runtime behaviour defined by a host-defined default loader. Implicitly async model – no code executes until requested modules are available and processed.
 
-##Export module
+## Export module
 > ES6
 
 ```js
@@ -22,7 +22,7 @@ function sum(x, y) {
 var pi = exports.pi = 3.141593;
 ```
 
-##Import module
+## Import module
 > ES6:
 
 ```js
@@ -35,7 +35,7 @@ import * as math from "lib/math";
 var math = require("lib/math");
 ```
 
-##Export default
+## Export default
 > ES6:
 
 ```js

--- a/ecma6/objectLiterals.md
+++ b/ecma6/objectLiterals.md
@@ -1,8 +1,8 @@
-#Enhanced Object Literals
+# Enhanced Object Literals
 
 Object literals are extended to support setting the prototype at construction, shorthand for foo: foo assignments, defining methods and making super calls. Together, these also bring object literals and class declarations closer together, and let object-based design benefit from some of the same conveniences.
 
-##Shorthands
+## Shorthands
 > ES6:
 
 ```js
@@ -19,7 +19,7 @@ var obj = {
 };
 ```
 
-##Methods
+## Methods
 > ES6:
 
 ```js
@@ -40,7 +40,7 @@ var obj = {
 };
 ```
 
-##Computed (dynamic) property names
+## Computed (dynamic) property names
 > ES6:
 
 ```js

--- a/ecma6/templateStrings.md
+++ b/ecma6/templateStrings.md
@@ -1,8 +1,8 @@
-#Template Strings
+# Template Strings
 
 Template strings provide syntactic sugar for constructing strings. This is similar to string interpolation features in Perl, Python and more. Optionally, a tag can be added to allow the string construction to be customized, avoiding injection attacks or constructing higher level data structures from string contents.
 
-##Multiline strings
+## Multiline strings
 
 > ES6:
 
@@ -17,7 +17,7 @@ Template strings provide syntactic sugar for constructing strings. This is simil
 "In JavaScript this is\n not legal.";
 ```
 
-##Templating
+## Templating
 
 > ES6:
 

--- a/readme.md
+++ b/readme.md
@@ -1,36 +1,36 @@
-#ECMAScript 6 Features
+# ECMAScript 6 Features
 
-###[Arrows](https://github.com/dnbard/es6-guide/blob/master/ecma6/arrows.md)
+### [Arrows](https://github.com/dnbard/es6-guide/blob/master/ecma6/arrows.md)
 Arrows are a function shorthand using the => syntax. They are syntactically similar to the related feature in C#, Java 8 and CoffeeScript. They support both expression and statement bodies. Unlike functions, arrows share the same lexical this as their surrounding code.
 
-###[Classes](https://github.com/dnbard/es6-guide/blob/master/ecma6/classes.md)
+### [Classes](https://github.com/dnbard/es6-guide/blob/master/ecma6/classes.md)
 ES6 classes are a simple sugar over the prototype-based OO pattern. Having a single convenient declarative form makes class patterns easier to use, and encourages interoperability. Classes support prototype-based inheritance, super calls, instance and static methods and constructors.
 
-###[Enhanced Object Literals](https://github.com/dnbard/es6-guide/blob/master/ecma6/objectLiterals.md)
+### [Enhanced Object Literals](https://github.com/dnbard/es6-guide/blob/master/ecma6/objectLiterals.md)
 Object literals are extended to support setting the prototype at construction, shorthand for foo: foo assignments, defining methods and making super calls. Together, these also bring object literals and class declarations closer together, and let object-based design benefit from some of the same conveniences.
 
-###[Template Strings](https://github.com/dnbard/es6-guide/blob/master/ecma6/templateStrings.md)
+### [Template Strings](https://github.com/dnbard/es6-guide/blob/master/ecma6/templateStrings.md)
 Template strings provide syntactic sugar for constructing strings. This is similar to string interpolation features in Perl, Python and more. Optionally, a tag can be added to allow the string construction to be customized, avoiding injection attacks or constructing higher level data structures from string contents.
 
-###[Destructuring](https://github.com/dnbard/es6-guide/blob/master/ecma6/destructuring.md)
+### [Destructuring](https://github.com/dnbard/es6-guide/blob/master/ecma6/destructuring.md)
 Destructuring allows binding using pattern matching, with support for matching arrays and objects. Destructuring is fail-soft, similar to standard object lookup foo["bar"], producing undefined values when not found.
 
-###[Default, Rest, Spread](https://github.com/dnbard/es6-guide/blob/master/ecma6/default.md)
+### [Default, Rest, Spread](https://github.com/dnbard/es6-guide/blob/master/ecma6/default.md)
 Callee-evaluated default parameter values. Turn an array into consecutive arguments in a function call. Bind trailing parameters to an array. Rest replaces the need for arguments and addresses common cases more directly.
 
-###[Let, Const](https://github.com/dnbard/es6-guide/blob/master/ecma6/let.md)
+### [Let, Const](https://github.com/dnbard/es6-guide/blob/master/ecma6/let.md)
 Block-scoped binding constructs. let is the new var. const is single-assignment. Static restrictions prevent use before assignment.
 
-###[Iterators, For..Of](https://github.com/dnbard/es6-guide/blob/master/ecma6/iterators.md)
+### [Iterators, For..Of](https://github.com/dnbard/es6-guide/blob/master/ecma6/iterators.md)
 Iterator objects enable custom iteration like CLR IEnumerable or Java Iterable. Generalize for..in to custom iterator-based iteration with for..of. Don’t require realizing an array, enabling lazy design patterns like LINQ.
 
-###[Generators](https://github.com/dnbard/es6-guide/blob/master/ecma6/generators.md)
+### [Generators](https://github.com/dnbard/es6-guide/blob/master/ecma6/generators.md)
 Generators simplify iterator-authoring using function* and yield. A function declared as function* returns a Generator instance. Generators are subtypes of iterators which include additional next and throw. These enable values to flow back into the generator, so yield is an expression form which returns a value (or throws).
 
-###[Modules](https://github.com/dnbard/es6-guide/blob/master/ecma6/modules.md)
+### [Modules](https://github.com/dnbard/es6-guide/blob/master/ecma6/modules.md)
 Language-level support for modules for component definition. Codifies patterns from popular JavaScript module loaders (AMD, CommonJS). Runtime behaviour defined by a host-defined default loader. Implicitly async model – no code executes until requested modules are available and processed.
 
-#ECMAScript 7 Features
+# ECMAScript 7 Features
 
-###[Array Comprehension](https://github.com/dnbard/es6-guide/blob/master/ecma6/arrayComprehension.md)
+### [Array Comprehension](https://github.com/dnbard/es6-guide/blob/master/ecma6/arrayComprehension.md)
 The array comprehension syntax is a JavaScript expression which allows you to quickly assemble a new array based on an existing one.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
